### PR TITLE
Require `message` on Spinner

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ Then configure the rules you want to use under the rules section.
 ## Supported Rules
 
 - [image-alt-text](https://github.com/grommet/eslint-plugin-grommet/blob/master/docs/rules/image-alt-text.md)
+- [spinner-message](<(https://github.com/grommet/eslint-plugin-grommet/blob/master/docs/rules/spinner-message.md)>)

--- a/docs/rules/spinner-message.md
+++ b/docs/rules/spinner-message.md
@@ -1,0 +1,28 @@
+# Rule to ensure message is applied to Spinner (spinner-message)
+
+[Spinner](https://v2.grommet.io/spinner) `message` prop is announced to screen reader users to provide better context on what is being loaded. It is recommended to use the object structure where both a "start" and "end" message are provided so screen reader users are alerted both when a spinner appears on the screen and when it disappears.
+
+Tips to consider:
+
+- Be specific. Don't just say, "Data is loading." Instead, provide clarity around what kind of data is loading. For example, "Loading user data."
+
+## Rule Details
+
+This rule aims to ensure `message` prop is applied to Spinner.
+
+Examples of **incorrect** code for this rule:
+
+```js
+<Spinner />
+```
+
+Examples of **correct** code for this rule:
+
+```js
+<Spinner
+  message={{ start: "Loading user data", end: "User data successfully loaded" }}
+/>
+
+// Object structure is preferred over string
+<Spinner message="Loading user data" />
+```

--- a/lib/rules/spinner-message.js
+++ b/lib/rules/spinner-message.js
@@ -9,6 +9,7 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+  type: 'problem',
   meta: {
     docs: {
       description: 'Rule to ensure message is applied to Spinner',

--- a/lib/rules/spinner-message.js
+++ b/lib/rules/spinner-message.js
@@ -2,7 +2,7 @@
  * @fileoverview Rule to ensure message is applied to Spinner
  * @author Taylor Seamans
  */
-"use strict";
+'use strict';
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -11,31 +11,31 @@
 module.exports = {
   meta: {
     docs: {
-      description: "Rule to ensure message is applied to Spinner",
-      category: "Best Practices",
+      description: 'Rule to ensure message is applied to Spinner',
+      category: 'Best Practices',
       recommended: true,
     },
     fixable: null,
     messages: {
-      "spinner-message":
-        'Spinner requires message prop that is descriptive about what is being loaded. It will be announced by screen readers. Message can be string or object { start: "", end: ""}, where "start" is announced when the Spinner appears and "end" is announced when spinner closes.',
+      'spinner-message':
+        'Spinner requires message prop that is descriptive about what is being loaded. It will be announced by screen readers. See Spinner docs: https://v2.grommet.io/spinner#message.',
     },
   },
 
   create: function (context) {
     return {
       JSXElement(node) {
-        if (node.openingElement.name.name === "Spinner") {
+        if (node.openingElement.name.name === 'Spinner') {
           let message = false;
           node.openingElement.attributes.forEach((attribute) => {
-            if (attribute.name.name === "message") {
+            if (attribute.name.name === 'message') {
               message = true;
             }
           });
           if (!message)
             context.report({
               node: node,
-              messageId: "spinner-message",
+              messageId: 'spinner-message',
             });
         }
       },

--- a/lib/rules/spinner-message.js
+++ b/lib/rules/spinner-message.js
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Rule to ensure message is applied to Spinner
+ * @author Taylor Seamans
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: "Rule to ensure message is applied to Spinner",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: null,
+    messages: {
+      "spinner-message":
+        'Spinner requires message prop that is descriptive about what is being loaded. It will be announced by screen readers. Message can be string or object { start: "", end: ""}, where "start" is announced when the Spinner appears and "end" is announced when spinner closes.',
+    },
+  },
+
+  create: function (context) {
+    return {
+      JSXElement(node) {
+        if (node.openingElement.name.name === "Spinner") {
+          let message = false;
+          node.openingElement.attributes.forEach((attribute) => {
+            if (attribute.name.name === "message") {
+              message = true;
+            }
+          });
+          if (!message)
+            context.report({
+              node: node,
+              messageId: "spinner-message",
+            });
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/spinner-message.js
+++ b/tests/lib/rules/spinner-message.js
@@ -2,14 +2,14 @@
  * @fileoverview Rule to ensure message is applied to Spinner.
  * @author Taylor Seamans
  */
-"use strict";
+'use strict';
 
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
 
-var rule = require("../../../lib/rules/spinner-message"),
-  RuleTester = require("eslint").RuleTester;
+var rule = require('../../../lib/rules/spinner-message'),
+  RuleTester = require('eslint').RuleTester;
 
 //------------------------------------------------------------------------------
 // Tests
@@ -18,7 +18,7 @@ var rule = require("../../../lib/rules/spinner-message"),
 var ruleTester = new RuleTester({
   parserOptions: { ecmaFeatures: { jsx: true } },
 });
-ruleTester.run("spinner-message", rule, {
+ruleTester.run('spinner-message', rule, {
   valid: [
     '<Spinner message="Loading users" />',
     '<Spinner message={{ start: "Loading users", end: "Users successfully loaded" }} />',
@@ -26,10 +26,10 @@ ruleTester.run("spinner-message", rule, {
 
   invalid: [
     {
-      code: "<Spinner />",
+      code: '<Spinner />',
       errors: [
         {
-          messageId: "spinner-message",
+          messageId: 'spinner-message',
         },
       ],
     },

--- a/tests/lib/rules/spinner-message.js
+++ b/tests/lib/rules/spinner-message.js
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Rule to ensure message is applied to Spinner.
+ * @author Taylor Seamans
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/spinner-message"),
+  RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester({
+  parserOptions: { ecmaFeatures: { jsx: true } },
+});
+ruleTester.run("spinner-message", rule, {
+  valid: [
+    '<Spinner message="Loading users" />',
+    '<Spinner message={{ start: "Loading users", end: "Users successfully loaded" }} />',
+  ],
+
+  invalid: [
+    {
+      code: "<Spinner />",
+      errors: [
+        {
+          messageId: "spinner-message",
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Flags if caller has not provided `message` for Spinner. Message is necessary for screen readers to announce relevant information around what kind of data is loading/has been loaded.

#### Where should the reviewer start?
docs/rules/spinner-message.md

#### Can you provide a link to an [AST Explorer](https://astexplorer.net/) example that validates the rule works as expected?

https://astexplorer.net/#/gist/5bbb79e725ce2454a15f261afdab2ef5/latest

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #15 

#### Screenshots (if appropriate)

#### Have docs been added/updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes. Add rule `spinner-message` to enforce `message` prop on Spinner.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.