### PR TITLE
Add formfield-prefer-children rule

### DIFF
--- a/docs/rules/formfield-prefer-children.md
+++ b/docs/rules/formfield-prefer-children.md
@@ -1,0 +1,23 @@
+# Recommend use of children with FormField as opposed to component property (formfield-prefer-children)
+
+It is considered Grommet best practice to implement inputs as children of [FormField](https://v2.grommet.io/formfield) as opposed to passing the input to FormField's component property.
+
+## Rule Details
+
+This rule aims to ensure FormField inputs are provided as children.
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+<FormField component={CheckBox}> />
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+<FormField>
+  <CheckBox />
+</FormField>
+```

--- a/lib/rules/formfield-prefer-children.js
+++ b/lib/rules/formfield-prefer-children.js
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview Recommend use of children with FormField as opposed to component property
+ * @author Taylor Seamans
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Recommend use of children with FormField as opposed to component property',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    fixable: null,
+    messages: {
+      'formfield-prefer-children':
+        'It is not recommended to use component property. Instead, implement input as a child of FormField.',
+    },
+  },
+
+  create: function (context) {
+    return {
+      JSXElement(node) {
+        if (node.openingElement.name.name === 'FormField') {
+          let component = false;
+          node.openingElement.attributes.forEach((attribute) => {
+            if (attribute.name.name === 'component') {
+              component = true;
+            }
+          });
+          if (component)
+            context.report({
+              node: node,
+              messageId: 'formfield-prefer-children',
+            });
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/formfield-prefer-children.js
+++ b/lib/rules/formfield-prefer-children.js
@@ -21,6 +21,7 @@ module.exports = {
       'formfield-prefer-children':
         'It is not recommended to use component property. Instead, implement input as a child of FormField.',
     },
+    type: 'suggestion',
   },
 
   create: function (context) {

--- a/tests/lib/rules/formfield-prefer-children.js
+++ b/tests/lib/rules/formfield-prefer-children.js
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Recommend use of children with FormField as opposed to component property
+ * @author Taylor Seamans
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/formfield-prefer-children'),
+  RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester({
+  parserOptions: { ecmaFeatures: { jsx: true } },
+});
+ruleTester.run('formfield-prefer-children', rule, {
+  valid: ['<FormField><TextInput /></FormField>'],
+
+  invalid: [
+    {
+      code: '<FormField component={CheckBox} />',
+      errors: [
+        {
+          messageId: 'formfield-prefer-children',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds rule to recommend use of children as opposed to `component` prop on FormField.

#### Where should the reviewer start?

#### Can you provide a link to an [AST Explorer](https://astexplorer.net/) example that validates the rule works as expected?

https://astexplorer.net/#/gist/fbaf9111ae6f91dddf56040c3ce83af3/latest

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #8 

#### Screenshots (if appropriate)

#### Have docs been added/updated?

Yes.

#### Should this PR be mentioned in the release notes?

Yes. Added `formfield-prefer-children` to recommend usage of children as opposed to `component` on FormField.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.