### PR TITLE
Add DataTable aria-describedby rule

### DIFF
--- a/docs/rules/datatable-aria-describedby.md
+++ b/docs/rules/datatable-aria-describedby.md
@@ -1,0 +1,26 @@
+# Rule to enforce aria-describedby on DataTable (datatable-aria-describedby)
+
+[DataTable](https://v2.grommet.io/datatable) requires `aria-describedby` prop that aligns with an `id` on a text element. This property allows screen readers to provide better context about the data of a DataTable.
+
+## Rule Details
+
+This rule aims to provide an accessible DataTable experience for screen reader users.
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+<Heading>Users</Heading>
+<DataTable columns={columns} data={data} />
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+<Heading id="user-table-heading">Users</Heading>
+<DataTable aria-describedby="user-table-heading" columns={columns} data={data} />
+
+
+```

--- a/lib/rules/datatable-aria-describedby.js
+++ b/lib/rules/datatable-aria-describedby.js
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview Rule to enforce aria-describedby on DataTable
+ * @author Taylor Seamans
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Rule to enforce aria-describedby on DataTable',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    fixable: null,
+    messages: {
+      'datatable-aria-describedby':
+        'DataTable requires `aria-describedby` property that aligns with an `id` on a text element that describes the context of the DataTable.',
+    },
+  },
+
+  create: function (context) {
+    return {
+      JSXElement(node) {
+        if (node.openingElement.name.name === 'DataTable') {
+          let ariaDescribedBy = false;
+          node.openingElement.attributes.forEach((attribute) => {
+            if (attribute.name.name === 'aria-describedby') {
+              ariaDescribedBy = true;
+            }
+          });
+          if (!ariaDescribedBy)
+            context.report({
+              node: node,
+              messageId: 'datatable-aria-describedby',
+            });
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/datatable-aria-describedby.js
+++ b/tests/lib/rules/datatable-aria-describedby.js
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Rule to enforce aria-describedby on DataTable
+ * @author Taylor Seamans
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/datatable-aria-describedby'),
+  RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester({
+  parserOptions: { ecmaFeatures: { jsx: true } },
+});
+ruleTester.run('datatable-aria-describedby', rule, {
+  valid: [
+    '<DataTable aria-describedby="some-heading" columns={columns} data={data} />',
+  ],
+
+  invalid: [
+    {
+      code: '<DataTable columns={columns} data={data} />',
+      errors: [
+        {
+          messageId: 'datatable-aria-describedby',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Flag if DataTable doesn't have `aria-describedby` property. Necessary to align with an `id` tag on the page to create accessible screenreader experience.

#### Where should the reviewer start?
lib/rules/datatable-aria-describedby.js

#### Can you provide a link to an [AST Explorer](https://astexplorer.net/) example that validates the rule works as expected?

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #16 

#### Screenshots (if appropriate)

#### Have docs been added/updated?
Yes.

#### Should this PR be mentioned in the release notes?

Yes. Added `datatable-aria-describedby` rule.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.
