### PR TITLE
Add anchor-label rule

### DIFF
--- a/docs/rules/anchor-label.md
+++ b/docs/rules/anchor-label.md
@@ -1,0 +1,25 @@
+# Rule to enforce descriptive anchor label (anchor-label)
+
+[Anchor](https://v2.grommet.io/anchor) should have a `label` or child string that is descriptive about where the anchor will navigate to when clicked as opposed to vague text such as "here" or "Click here".
+
+This is critical for users that navigate via screen readers because often they use quick commands to view all anchors within a page. If an anchor is only labeled with "here" or "Click here", a user navigating via screen reader will have no context around where this link will lead.
+
+## Rule Details
+
+This rule aims to ensure that vague text such as "here" or "Click here" is not used as label text for Anchors.
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+You can learn more <Anchor label="here" href="/some-page" />.
+
+To learn more, <Anchor label="click here" href="/some-page" />.
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+To learn more, read more about <Anchor "Grommet docs" href="https://grommet.io" />.
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ module.exports.configs = {
   recommended: {
     plugins: ['grommet'],
     rules: {
+      'grommet/anchor-label': 'warn',
       'grommet/button-single-kind': 'error',
       'grommet/datatable-aria-describedby': 'error',
       'grommet/datatable-groupby-onmore': 'error',

--- a/lib/rules/anchor-label.js
+++ b/lib/rules/anchor-label.js
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Rule to enforce descriptive anchor label
+ * @author Taylor Seamans
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Rule to enforce descriptive anchor label',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    fixable: null,
+    messages: {
+      'anchor-label':
+        'Anchor should have a descriptive label that provides clear context about where it will navigate to.',
+    },
+  },
+
+  create: function (context) {
+    return {
+      JSXElement(node) {
+        if (node?.openingElement?.name?.name === 'Anchor') {
+          let vagueLabel = false;
+          const regexp = /.*here.*/gi;
+          node.openingElement.attributes.forEach((attribute) => {
+            if (attribute?.name?.name === 'label') {
+              vagueLabel = regexp.test(attribute.value.raw);
+            }
+          });
+          if (node.children)
+            node.children.map((child) => {
+              vagueLabel = regexp.test(child.value);
+            });
+          if (vagueLabel)
+            context.report({
+              node: node,
+              messageId: 'anchor-label',
+            });
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/anchor-label.js
+++ b/tests/lib/rules/anchor-label.js
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Rule to enforce descriptive anchor label
+ * @author Taylor Seamans
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/anchor-label'),
+  RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester({
+  parserOptions: { ecmaFeatures: { jsx: true } },
+});
+ruleTester.run('anchor-label', rule, {
+  valid: [
+    '<Anchor label="Grommet docs" href="https://grommet.io" />',
+    '<Anchor href="https://grommet.io">Grommet docs</Anchor>',
+  ],
+  invalid: [
+    {
+      code: '<Anchor label="here" href="/some-page" />',
+      errors: [
+        {
+          messageId: 'anchor-label',
+        },
+      ],
+    },
+    {
+      code: '<Anchor label="Click here" href="/some-page" />',
+      errors: [
+        {
+          messageId: 'anchor-label',
+        },
+      ],
+    },
+    {
+      code: '<Anchor href="/some-page">Click here</Anchor>',
+      errors: [
+        {
+          messageId: 'anchor-label',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds rule to check if Anchor has vague label of "here" or "Click here" (anything involving string "here"). If so, it is flagged.

This is necessary because screen reader users often navigate via quick commands that aggregate all anchors within a page. If the Anchor is labeled with just "here" or "Click here", then they will have no context on where this will lead, creating an inaccessible experience.

#### Where should the reviewer start?
tests/lib/rules/anchor-label.js

#### Can you provide a link to an [AST Explorer](https://astexplorer.net/) example that validates the rule works as expected?

https://astexplorer.net/#/gist/c10c67d72fc7702a65c667bda874e530/10032521ef1545e47ac51b58f7c8fe14e83e6821

#### Any background context you want to provide?

Accessibility best practices.

#### What are the relevant issues?

Closes #17 

#### Screenshots (if appropriate)

#### Have docs been added/updated?

Yes.

#### Should this PR be mentioned in the release notes?
Yes. Added `anchor-label` rule.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.