### PR TITLE
Add button-icon-a11ytitle rule

### DIFF
--- a/docs/rules/button-icon-a11ytitle.md
+++ b/docs/rules/button-icon-a11ytitle.md
@@ -1,0 +1,23 @@
+# Rule to enforce a11yTitle on icon-only buttons (button-icon-a11ytitle)
+
+When [Button](https://v2.grommet.io/button) has an `icon` but no `label` (icon-only), it should have an `a11yTitle` or `aria-label` that is descriptive about the action of the button.
+
+This is critical for users that rely on assistive technology because the default a11yTitle on an icon may not be fitting for the use case of the button. For example,
+
+## Rule Details
+
+This rule aims to ensure `a11yTitle` or `aria-label` is present on icon-only buttons.
+
+Examples of **incorrect** code for this rule:
+
+```js
+<Button icon={<FormClose />} />
+```
+
+Examples of **correct** code for this rule:
+
+```js
+<Button icon={<FormClose />} a11yTitle="Close Edit Profile Layer" />
+
+<Button icon={<FormClose />} aria-label="Close Edit Profile Layer" />
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ module.exports.configs = {
     plugins: ['grommet'],
     rules: {
       'grommet/anchor-label': 'warn',
+      'grommet/button-icon-a11ytitle': 'error',
       'grommet/button-single-kind': 'error',
       'grommet/datatable-aria-describedby': 'error',
       'grommet/datatable-groupby-onmore': 'error',

--- a/lib/rules/button-icon-a11ytitle.js
+++ b/lib/rules/button-icon-a11ytitle.js
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Rule to enforce a11yTitle on icon-only buttons
+ * @author Taylor Seamans
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Rule to enforce a11yTitle on icon-only buttons',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    fixable: null,
+    messages: {
+      'button-icon-a11ytitle':
+        'Icon-only button requires a11yTitle or aria-label that describes the action of the button.',
+    },
+  },
+
+  create: function (context) {
+    return {
+      JSXElement(node) {
+        if (node?.openingElement?.name?.name === 'Button') {
+          let a11yTitle;
+          let label;
+          let icon;
+
+          node?.openingElement?.attributes?.forEach((attribute) => {
+            if (attribute?.name?.name === 'label') {
+              label = true;
+            } else if (attribute?.name?.name === 'icon') {
+              icon = true;
+            } else if (
+              attribute?.name?.name === 'a11yTitle' ||
+              attribute?.name?.name === 'aria-label'
+            ) {
+              a11yTitle = true;
+            }
+          });
+
+          if (!label && icon && !a11yTitle)
+            context.report({
+              node: node,
+              messageId: 'button-icon-a11ytitle',
+            });
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/button-icon-a11ytitle.js
+++ b/tests/lib/rules/button-icon-a11ytitle.js
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Rule to enforce a11yTitle on icon-only buttons
+ * @author Taylor Seamans
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/button-icon-a11ytitle'),
+  RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester({
+  parserOptions: { ecmaFeatures: { jsx: true } },
+});
+ruleTester.run('button-icon-a11ytitle', rule, {
+  valid: [
+    '<Button icon={<FormClose />} a11yTitle="Exit Edit Profile Layer" />',
+    '<Button icon={<FormClose />} aria-label="Exit Edit Profile Layer" />',
+  ],
+
+  invalid: [
+    {
+      code: '<Button icon={<FormClose />} />',
+      errors: [
+        {
+          messageId: 'button-icon-a11ytitle',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds rule to ensure that icon-only buttons have an a11yTitle or aria-label so that the action of the button is clear to those who use assistive technologies.
 
#### Where should the reviewer start?
lib/rules/button-icon-a11ytitle.js

#### Can you provide a link to an [AST Explorer](https://astexplorer.net/) example that validates the rule works as expected?

https://astexplorer.net/#/gist/095a0e22eac6270a717b67752003a763/dcd2b93a8c03ca618ea4356784c08218f58e15b2

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #14 

#### Screenshots (if appropriate)

Tested local in design system site

<img width="1066" alt="Screen Shot 2021-12-21 at 3 18 09 PM" src="https://user-images.githubusercontent.com/12522275/147010309-bb606188-a0e0-47e7-a02d-00449822028d.png">

#### Have docs been added/updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes. Added `button-icon-a11ytitle`.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.