### PR TITLE
Add hoverIndicator onClick rule

### DIFF
--- a/docs/rules/hoverindicator-onclick.md
+++ b/docs/rules/hoverindicator-onclick.md
@@ -1,0 +1,29 @@
+# Rule to enforce use of onClick with hoverIndicator on Box and Card (hoverindicator-onclick)
+
+When using `hoverIndicator` on [Box](https://v2.grommet.io/box) or [Card](https://v2.grommet.io/card), you must also provide an `onClick` property in order for the hover behavior to be applied.
+
+Hover indication is a way to inform users that an element is clickable. Therefore, if an element is not clickable, no hover behavior will be applied.
+
+## Rule Details
+
+This rule aims to ensure that `onClick` is always applied when `hoverIndicator` is used.
+
+Examples of **incorrect** code for this rule:
+
+```js
+<Box hoverIndicator>content<Box>
+
+<Box hoverIndicator={{ elevation: 'large' }}>content<Box>
+
+<Card hoverIndicator={{ elevation: 'large' }}>content<Card>
+```
+
+Examples of **correct** code for this rule:
+
+```js
+<Box hoverIndicator onClick={() => {}}>content<Box>
+
+<Box hoverIndicator={{ elevation: 'large' }} onClick={() => {}}>content<Box>
+
+<Card hoverIndicator={{ elevation: 'large' }} onClick={() => {}}>content<Card>
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,7 @@ module.exports.configs = {
       'grommet/formfield-htmlfor-id': 'warn',
       'grommet/formfield-name': 'warn',
       'grommet/formfield-prefer-children': 'warn',
+      'grommet/hoverindicator-onclick': 'warn',
       'grommet/image-alt-text': 'warn',
       'grommet/spinner-message': 'warn',
     },

--- a/lib/rules/hoverindicator-onclick.js
+++ b/lib/rules/hoverindicator-onclick.js
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview Rule to enforce use of onClick with hoverIndicator on Box and Card
+ * @author Taylor Seamans
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Rule to enforce use of onClick with hoverIndicator on Box and Card',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'https://github.com/grommet/eslint-plugin-grommet/blob/master/docs/rules/hoverindicator-onclick.md',
+    },
+    fixable: null,
+    messages: {
+      'hoverindicator-onclick': `Using hoverIndicator without onClick will not apply the hover behavior. 
+      A hover indicator is intended to provide feedback that an element is clickable, and therefore 
+      is not applied to static elements.`,
+    },
+  },
+
+  create: function (context) {
+    return {
+      JSXElement(node) {
+        if (
+          node?.openingElement?.name?.name === 'Card' ||
+          node?.openingElement?.name?.name === 'Box'
+        ) {
+          let hoverIndicator = false;
+          let onClick = false;
+          node?.openingElement?.attributes?.forEach((attribute) => {
+            if (attribute?.name?.name === 'hoverIndicator') {
+              hoverIndicator = true;
+            } else if (attribute?.name?.name === 'onClick') {
+              onClick = true;
+            }
+          });
+          if (hoverIndicator && !onClick)
+            context.report({
+              node: node,
+              messageId: 'hoverindicator-onclick',
+            });
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/hoverindicator-onclick.js
+++ b/tests/lib/rules/hoverindicator-onclick.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Rule to enforce use of onClick with hoverIndicator on Box and Card
+ * @author Taylor Seamans
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/hoverindicator-onclick'),
+  RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester({
+  parserOptions: { ecmaFeatures: { jsx: true } },
+});
+ruleTester.run('hoverindicator-onclick', rule, {
+  valid: [
+    '<Box hoverIndicator={{ elevation: "large" }} onClick={onClick}>content</Box>',
+    '<Card hoverIndicator={{ elevation: "large" }} onClick={onClick}>content</Card>',
+    '<Box hoverIndicator onClick={onClick}>content</Box>',
+    '<Card hoverIndicator onClick={onClick}>content</Card>',
+  ],
+
+  invalid: [
+    {
+      code: '<Box hoverIndicator>content</Box>',
+      errors: [
+        {
+          messageId: 'hoverindicator-onclick',
+        },
+      ],
+    },
+    {
+      code: '<Card hoverIndicator>content</Card>',
+      errors: [
+        {
+          messageId: 'hoverindicator-onclick',
+        },
+      ],
+    },
+    {
+      code: "<Box hoverIndicator={{ elevation: 'large' }}>content</Box>",
+      errors: [
+        {
+          messageId: 'hoverindicator-onclick',
+        },
+      ],
+    },
+    {
+      code: "<Card hoverIndicator={{ elevation: 'large' }}>content</Card>",
+      errors: [
+        {
+          messageId: 'hoverindicator-onclick',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds rule to check that `hoverIndicator` prop is always paired with `onClick`

#### Where should the reviewer start?
docs/rules/hoverindicator-onclick.md

#### Can you provide a link to an [AST Explorer](https://astexplorer.net/) example that validates the rule works as expected?

https://astexplorer.net/#/gist/8472f65002e82a8da746829c483f7d20/535810ae18fc2e0cab3e4eb5f0773e550d49d364

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #36 

#### Screenshots (if appropriate)

#### Have docs been added/updated?
Yes.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.