### PR TITLE
Refine `button-icon-a11yTitle` rule to notice `tip`

### DIFF
--- a/lib/rules/button-icon-a11ytitle.js
+++ b/lib/rules/button-icon-a11ytitle.js
@@ -20,7 +20,7 @@ module.exports = {
     fixable: null,
     messages: {
       'button-icon-a11ytitle': `Icon-only button requires 'a11yTitle', 'aria-label', or 'tip' describing the action of the button. Use 'tip' if it would be valuable for the description to appear on hover.`,
-      'button-icon-custom-tip': `Because 'tip' is a JSX Element, an 'a11yTitle' or 'aria-label' describing the action of the button is required to help users of assisstive technologies.`,
+      'button-icon-custom-tip': `Because 'tip' is an object, an 'a11yTitle' or 'aria-label' describing the action of the button is required to help users of assisstive technologies.`,
     },
     schema: [],
   },

--- a/lib/rules/button-icon-a11ytitle.js
+++ b/lib/rules/button-icon-a11ytitle.js
@@ -20,7 +20,7 @@ module.exports = {
     fixable: null,
     messages: {
       'button-icon-a11ytitle': `Icon-only button requires 'a11yTitle', 'aria-label', or 'tip' describing the action of the button. Use 'tip' if it would be valuable for the description to appear on hover.`,
-      'button-icon-custom-tip': `Because 'tip' is an object, an 'a11yTitle' or 'aria-label' describing the action of the button is required to help users of assisstive technologies.`,
+      'button-icon-custom-tip': `Because 'tip' is implemented as a custom object an `aria-label` is not automatically added to button. Include an accompanying 'a11yTitle' or 'aria-label' describing the action of the button to help users of assistive technologies.`,
     },
     schema: [],
   },

--- a/lib/rules/button-icon-a11ytitle.js
+++ b/lib/rules/button-icon-a11ytitle.js
@@ -20,6 +20,7 @@ module.exports = {
     fixable: null,
     messages: {
       'button-icon-a11ytitle': `Icon-only button requires 'a11yTitle', 'aria-label', or 'tip' describing the action of the button. Use 'tip' if it would be valuable for the description to appear on hover.`,
+      'button-icon-custom-tip': `Because 'tip' is a JSX Element, an 'a11yTitle' or 'aria-label' describing the action of the button is required to help users of assisstive technologies.`,
     },
     schema: [],
   },
@@ -39,7 +40,7 @@ module.exports = {
             } else if (attribute?.name?.name === 'icon') {
               icon = true;
             } else if (attribute?.name?.name === 'tip') {
-              tip = true;
+              tip = attribute.value.type;
             } else if (
               attribute?.name?.name === 'a11yTitle' ||
               attribute?.name?.name === 'aria-label'
@@ -54,6 +55,11 @@ module.exports = {
             context.report({
               node: node,
               messageId: 'button-icon-a11ytitle',
+            });
+          else if (iconOnly && tip === 'JSXExpressionContainer' && !a11yTitle)
+            context.report({
+              node: node,
+              messageId: 'button-icon-custom-tip',
             });
         }
       },

--- a/lib/rules/button-icon-a11ytitle.js
+++ b/lib/rules/button-icon-a11ytitle.js
@@ -19,7 +19,7 @@ module.exports = {
     },
     fixable: null,
     messages: {
-      'button-icon-a11ytitle': `Icon-only button requires 'a11yTitle' or 'aria-label' describing the action of the button.`,
+      'button-icon-a11ytitle': `Icon-only button requires 'a11yTitle', 'aria-label', or 'tip' describing the action of the button. Use 'tip' if it would be valuable for the description to appear on hover.`,
     },
     schema: [],
   },
@@ -31,12 +31,15 @@ module.exports = {
           let a11yTitle;
           let label;
           let icon;
+          let tip;
 
           node?.openingElement?.attributes?.forEach((attribute) => {
             if (attribute?.name?.name === 'label') {
               label = true;
             } else if (attribute?.name?.name === 'icon') {
               icon = true;
+            } else if (attribute?.name?.name === 'tip') {
+              tip = true;
             } else if (
               attribute?.name?.name === 'a11yTitle' ||
               attribute?.name?.name === 'aria-label'
@@ -45,7 +48,9 @@ module.exports = {
             }
           });
 
-          if (!label && icon && !a11yTitle)
+          const iconOnly = !label && icon;
+
+          if (iconOnly && !tip && !a11yTitle)
             context.report({
               node: node,
               messageId: 'button-icon-a11ytitle',

--- a/tests/lib/rules/button-icon-a11ytitle.js
+++ b/tests/lib/rules/button-icon-a11ytitle.js
@@ -22,6 +22,7 @@ ruleTester.run('button-icon-a11ytitle', rule, {
   valid: [
     '<Button icon={<FormClose />} a11yTitle="Exit Edit Profile Layer" />',
     '<Button icon={<FormClose />} aria-label="Exit Edit Profile Layer" />',
+    '<Button icon={<FormClose />} tip="Exit Edit Profile Layer" />',
   ],
 
   invalid: [

--- a/tests/lib/rules/button-icon-a11ytitle.js
+++ b/tests/lib/rules/button-icon-a11ytitle.js
@@ -33,5 +33,13 @@ ruleTester.run('button-icon-a11ytitle', rule, {
         },
       ],
     },
+    {
+      code: '<Button icon={<FormClose />} tip={{ content: "Close" }} />',
+      errors: [
+        {
+          messageId: 'button-icon-custom-tip',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Refines the icon only button rule to check if the button has a tip. If the tip is a string, grommet will automatically add an `a11yTitle`, so this shouldn't be flagged as an error. If `tip` is an object, it should flag this because grommet doesn't add an `a11yTitle` in that case.

#### Where should the reviewer start?
lib/rules/button-icon-a11ytitle.js

#### Can you provide a link to an [AST Explorer](https://astexplorer.net/) example that validates the rule works as expected?

https://astexplorer.net/#/gist/1b58b77cda7231422323021160f6860c/a22e7cbf27822ffdba7fb8745ea7d4cc80b6f5ae

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #49 

#### Screenshots (if appropriate)

#### Have docs been added/updated?

No updates.

#### Should this PR be mentioned in the release notes?

Yes.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.